### PR TITLE
DISTPG-551: Indicate which version is provided on the virtual packages

### DIFF
--- a/postgres/control
+++ b/postgres/control
@@ -135,7 +135,7 @@ Depends:
  tzdata,
  ${misc:Depends},
  ${shlibs:Depends}
-Provides: percona-postgresql-contrib-12, postgresql-contrib-12, postgresql-12
+Provides: percona-postgresql-contrib-12, postgresql-contrib-12 (= ${binary:Version}), postgresql-12 (= ${binary:Version})
 Recommends: sysstat
 Description: The World's Most Advanced Open Source Relational Database
  PostgreSQL, also known as Postgres, is a free and open-source relational
@@ -160,7 +160,7 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends}
 Suggests: percona-postgresql-12, percona-postgresql-doc-12
-Provides: percona-postgresql-client, postgresql-client, postgresql-client-12
+Provides: percona-postgresql-client, postgresql-client (= ${binary:Version}), postgresql-client-12 (= ${binary:Version})
 Conflicts: postgresql-server-dev-12 (<< 12.1-2~)
 Replaces: postgresql-server-dev-12 (<< 12.1-2~)
 Description: front-end programs for PostgreSQL 12


### PR DESCRIPTION
This adds the version on the virtual package "Provides" for the Debian packages, which fixes third-party packages that depend on specific versions of the packages that the Percona packages replaces.

Version for main branch.

Not familiar enough with the package build process to test this.

(I suspect this is a change to trivial for copyright to be applicable)