### PR TITLE
DISTPG-551: PostgreSQL 14.x: Indicate which version is provided on the virtual packages

### DIFF
--- a/postgres/control
+++ b/postgres/control
@@ -144,7 +144,7 @@ Depends:
  tzdata,
  ${misc:Depends},
  ${shlibs:Depends}
-Provides: percona-postgresql-contrib-14, postgresql-contrib-14, postgresql-14
+Provides: percona-postgresql-contrib-14, postgresql-contrib-14 (= ${binary:Version}), postgresql-14 (= ${binary:Version})
 Recommends: sysstat
 Description: The World's Most Advanced Open Source Relational Database
  PostgreSQL, also known as Postgres, is a free and open-source relational
@@ -168,7 +168,7 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends}
 Suggests: percona-postgresql-14, percona-postgresql-doc-14
-Provides: percona-postgresql-client, postgresql-client, postgresql-client-14
+Provides: percona-postgresql-client, postgresql-client (= ${binary:Version}), postgresql-client-14 (= ${binary:Version})
 Conflicts: postgresql-server-dev-14 (<< 14.6-1~)
 Replaces: postgresql-server-dev-14 (<< 14.6-1~)
 Description: front-end programs for PostgreSQL 14


### PR DESCRIPTION
This adds the version on the virtual package "Provides" for the Debian packages, which fixes third-party packages that depend on specific versions of the packages that the Percona packages replaces.

Version for latest 14.x branch.

Not familiar enough with the package build process to test this.

(I suspect this is a change to trivial for copyright to be applicable)