### PR TITLE
Revert "[PG-783]: It was bug in native patchelf package that sets the…

### DIFF
--- a/pg_tarballs/pg_tarballs_builder.sh
+++ b/pg_tarballs/pg_tarballs_builder.sh
@@ -1321,19 +1321,6 @@ build_etcd(){
 	build_status "ends" "etcd"
 }
 
-get_updated_patchelf(){
-
-        # Get patchelf latest build to avoid a bug in older version
-        ARCH=$(uname -m)
-        rm -rf /tmp/patchelf
-        mkdir -p /tmp/patchelf
-        cd /tmp/patchelf
-        wget https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-${ARCH}.tar.gz
-        tar -xvzf patchelf-0.18.0-${ARCH}.tar.gz
-        mv /tmp/patchelf/bin/patchelf /usr/bin/
-        cd -
-}
-
 set_rpath(){
 
         directory="$1"  # Change this to your target directory
@@ -1360,8 +1347,6 @@ set_rpath(){
 }
 
 set_rpath_all_products(){
-
-	get_updated_patchelf
 
 	ARCH=$(uname -m)
 	# Set rpath of all binaries in tarball


### PR DESCRIPTION
… rpath. Updated script to download latest patchelf binary to set rpath. (#517)"

This reverts commit ff94789aaed244312436d4e2ae4ac8b448125fe0.