### PR TITLE
Changes in pgpool-II 4.7.1- Rename libpcp to libpgpoolpcp to avoid conflict with RHEL PCP library

### DIFF
--- a/pg_tarballs/pg_tarballs_builder.sh
+++ b/pg_tarballs/pg_tarballs_builder.sh
@@ -1412,7 +1412,7 @@ build_pgpool(){
 	cp -rp ${DEPENDENCY_LIBS_PATH}/lib/libldap.* ${PGPOOL_PREFIX}/lib/
 	cp -rp ${DEPENDENCY_LIBS_PATH}/lib/liblber* ${PGPOOL_PREFIX}/lib/
 	cp -rp ${DEPENDENCY_LIBS_PATH}/lib/libmemcached.* ${PGPOOL_PREFIX}/lib/
-	cp -rp ${PGPOOL_PREFIX}/lib/libpcp.so* ${POSTGRESQL_PREFIX}/lib/
+	cp -rp ${PGPOOL_PREFIX}/lib/libpgpoolpcp.so* ${POSTGRESQL_PREFIX}/lib/
 	cp -rp ${DEPENDENCY_LIBS_PATH}/lib/libmemcached.* ${POSTGRESQL_PREFIX}/lib/
 	cp -rp ${DEPENDENCY_LIBS_PATH}/lib/libcrypt.so* ${PGPOOL_PREFIX}/lib/
 	cp -rp ${DEPENDENCY_LIBS_PATH}/lib/libxcrypt.so* ${PGPOOL_PREFIX}/lib/


### PR DESCRIPTION
https://www.pgpool.net/docs/4.7/en/html/release-4-7-1.html
Rename libpcp to libpgpoolpcp to avoid conflict with RHEL PCP library. (Bo Peng)

The libpcp.so library provided by Pgpool-II conflicts with libpcp.so shipped by RHEL. To avoid this conflict, the Pgpool-II libpcp library has been renamed to libpgpoolpcp.